### PR TITLE
Refactoring use of IConfiguration

### DIFF
--- a/Solutions/Corvus.SpecFlow.Extensions.CosmosClient/Corvus/SpecFlow/Extensions/CosmosDbContextBindings.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions.CosmosClient/Corvus/SpecFlow/Extensions/CosmosDbContextBindings.cs
@@ -10,7 +10,7 @@ namespace Corvus.SpecFlow.Extensions
     using System.Threading.Tasks;
     using Corvus.Extensions;
     using Corvus.Extensions.Cosmos;
-    using Corvus.Extensions.Cosmos.Crypto;
+    using Corvus.Specflow.Extensions;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Extensions.Configuration;

--- a/Solutions/Corvus.SpecFlow.Extensions.CosmosClient/Corvus/SpecFlow/Extensions/SecretHelper.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions.CosmosClient/Corvus/SpecFlow/Extensions/SecretHelper.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-namespace Corvus.Extensions.Cosmos.Crypto
+namespace Corvus.Specflow.Extensions
 {
     using System.Threading.Tasks;
 
@@ -17,7 +17,7 @@ namespace Corvus.Extensions.Cosmos.Crypto
     /// We need this as different tenants may be configured to use different keyvaults (in a BYO scenario).
     /// Therefore we cannot simply configure the keyvault fallback for configuration.
     /// </remarks>
-    public static class SecretHelper
+    internal static class SecretHelper
     {
         /// <summary>
         ///     Attempts to retrieve a value from configuration. If it doesn't exist, attempts to retrieve it from KeyVault.
@@ -37,7 +37,7 @@ namespace Corvus.Extensions.Cosmos.Crypto
         /// <returns>
         ///     The secret.
         /// </returns>
-        public static async Task<string> GetSecretFromConfigurationOrKeyVaultAsync(
+        internal static async Task<string> GetSecretFromConfigurationOrKeyVaultAsync(
             IConfiguration configuration,
             string configurationKey,
             string keyVaultName,
@@ -78,7 +78,7 @@ namespace Corvus.Extensions.Cosmos.Crypto
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        public static async Task<string> GetSecretFromKeyVaultAsync(
+        internal static async Task<string> GetSecretFromKeyVaultAsync(
             IConfiguration configuration,
             string keyVaultName,
             string keyVaultSecretName)


### PR DESCRIPTION
This project only uses IConfiguration inside spec projects. The SecretHelper class was moved into the Specs project and made internal, so that the pattern of passing in an IConfiguration is limited to test code only. 

Fixes #36 